### PR TITLE
Fix Rails `connection_config` deprecation

### DIFF
--- a/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/utils5x.rb
+++ b/lib/appoptics_apm/frameworks/rails/inst/connection_adapters/utils5x.rb
@@ -26,7 +26,7 @@ module AppOpticsAPM
               opts[:Backtrace] = AppOpticsAPM::API.backtrace
             end
 
-            if ActiveRecord::Base.method_defined?(:connection_db_config)
+            if ActiveRecord::Base.respond_to?(:connection_db_config)
               # Rails 6.1++ deprecates connection_config
               config = ActiveRecord::Base.connection_db_config.configuration_hash
             else


### PR DESCRIPTION
`ActiveRecord::Base.method_defined?(:connection_db_config)` did not return true, even though it exists.  Instead we need to use `respond_to?` which is what it was changed to in [5.0.0](https://github.com/solarwinds/appoptics-apm-ruby/blob/07ec75694d01fe9bf7fa182fce3957e8d7622028/lib/solarwinds_apm/frameworks/rails/inst/connection_adapters/utils5x.rb#L69)

https://github.com/solarwinds/appoptics-apm-ruby/issues/159